### PR TITLE
Support for changing dt during training

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Release history
 
 - Added the ``keras_spiking.Alpha`` filter, which provides second-order lowpass
   filtering for better noise removal for spiking layers. (`#4`_)
+- Added ``keras_spiking.callbacks.DtScheduler``, which can be used to update layer
+  ``dt`` parameters during training. (`#5`_)
 
 **Changed**
 
@@ -36,6 +38,7 @@ Release history
 
 .. _#3: https://github.com/nengo/keras-spiking/pull/3
 .. _#4: https://github.com/nengo/keras-spiking/pull/4
+.. _#5: https://github.com/nengo/keras-spiking/pull/5
 
 0.1.0 (August 14, 2020)
 -----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Release history
   filtering for better noise removal for spiking layers. (`#4`_)
 - Added ``keras_spiking.callbacks.DtScheduler``, which can be used to update layer
   ``dt`` parameters during training. (`#5`_)
+- Added ``keras_spiking.default.dt``, which can be used to set the default ``dt``
+  for all layers that don't directly specify ``dt``. (`#5`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Release history
   number of timesteps as their inputs. This makes it easier to process create
   multi-layer spiking networks, where time is preserved throughout the network.
   The spiking fashion-MNIST example has been updated accordingly. (`#3`_)
+- Layers now support multi-dimensional inputs (e.g., output of ``Conv2D`` layers).
+  (`#5`_)
 
 .. _#3: https://github.com/nengo/keras-spiking/pull/3
 .. _#4: https://github.com/nengo/keras-spiking/pull/4

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+import tensorflow as tf
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_session(request):
+    # free up resources between tests
+    tf.keras.backend.clear_session()

--- a/docs/examples/spiking-fashion-mnist.ipynb
+++ b/docs/examples/spiking-fashion-mnist.ipynb
@@ -575,7 +575,12 @@
     "throughout the model—not only on the final layer—in the case that there are multiple\n",
     "spiking layers. For the final layer, we can pass `return_sequences=False` to have the\n",
     "layer only return the output of the final timestep, rather than the outputs of all\n",
-    "timesteps."
+    "timesteps.\n",
+    "\n",
+    "When working with multiple KerasSpiking layers, we often want them to all share the\n",
+    "same `dt`. We can use `keras_spiking.default.dt` to change the default dt for all\n",
+    "layers. Note that this will only affect layers created _after_ the default is changed;\n",
+    "this will not retroactively affect previous layers."
    ]
   },
   {
@@ -584,18 +589,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt = 0.01\n",
+    "keras_spiking.default.dt = 0.01\n",
     "\n",
     "filtered_model = tf.keras.Sequential(\n",
     "    [\n",
     "        tf.keras.layers.Reshape((-1, 28 * 28), input_shape=(None, 28, 28)),\n",
     "        tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(128)),\n",
-    "        keras_spiking.SpikingActivation(\"relu\", spiking_aware_training=True, dt=dt),\n",
+    "        keras_spiking.SpikingActivation(\"relu\", spiking_aware_training=True),\n",
     "        # add a lowpass filter on output of spiking layer\n",
-    "        # note: the lowpass dt doesn't necessarily need to be the same as the\n",
-    "        # SpikingActivation dt, but it's probably a good idea to keep them in sync\n",
-    "        # so that if we change dt the relative effect of the lowpass filter is unchanged\n",
-    "        keras_spiking.Lowpass(tau=0.1, dt=dt, return_sequences=False),\n",
+    "        keras_spiking.Lowpass(tau=0.1, return_sequences=False),\n",
     "        tf.keras.layers.Dense(10),\n",
     "    ]\n",
     ")\n",

--- a/docs/examples/spiking-fashion-mnist.ipynb
+++ b/docs/examples/spiking-fashion-mnist.ipynb
@@ -415,7 +415,11 @@
     "per timestep), so the activity is no longer temporally sparse.\n",
     "\n",
     "Thus setting `dt` represents a trade-off between accuracy and temporal sparsity.\n",
-    "Choosing the appropriate value will depend on the demands of your application."
+    "Choosing the appropriate value will depend on the demands of your application.\n",
+    "\n",
+    "In some cases it can be useful to modify `dt` over the course of training. For example,\n",
+    "we could start with a large `dt` and then gradually decrease it over time. See\n",
+    "`keras_spiking.callbacks.DtScheduler` for more details."
    ]
   },
   {

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -16,3 +16,11 @@ Regularizers
 
     .. autoautosummary:: keras_spiking.regularizers
         :nosignatures:
+
+Callbacks
+---------
+
+.. automodule:: keras_spiking.callbacks
+
+    .. autoautosummary:: keras_spiking.callbacks
+        :nosignatures:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -24,3 +24,11 @@ Callbacks
 
     .. autoautosummary:: keras_spiking.callbacks
         :nosignatures:
+
+Configuration
+-------------
+
+.. automodule:: keras_spiking.config
+
+    .. autoautosummary:: keras_spiking.config
+        :nosignatures:

--- a/keras_spiking/__init__.py
+++ b/keras_spiking/__init__.py
@@ -4,6 +4,7 @@ __copyright__ = "2020-2020, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"
 from keras_spiking.version import version as __version__
 
+from keras_spiking import callbacks, layers, regularizers
 from keras_spiking.layers import (
     Alpha,
     AlphaCell,

--- a/keras_spiking/__init__.py
+++ b/keras_spiking/__init__.py
@@ -5,6 +5,7 @@ __license__ = "Free for non-commercial use; see LICENSE.rst"
 from keras_spiking.version import version as __version__
 
 from keras_spiking import callbacks, layers, regularizers
+from keras_spiking.config import default
 from keras_spiking.layers import (
     Alpha,
     AlphaCell,

--- a/keras_spiking/callbacks.py
+++ b/keras_spiking/callbacks.py
@@ -1,0 +1,93 @@
+"""
+Callbacks for use with KerasSpiking models.
+"""
+
+import tensorflow as tf
+
+
+class DtScheduler(tf.keras.callbacks.Callback):
+    """
+    A callback for updating Layer ``dt`` attributes during training.
+
+    This uses the same scheduler interface as `TensorFlow's learning rate schedulers
+    <https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/schedules>`_,
+    so any of those built-in schedules can be used to adjust ``dt``, or a custom
+    function implementing the same interface.
+
+    When using this functionality, ``dt`` should be initialized as a ``tf.Variable``,
+    and that Variable should be passed as the ``dt`` parameter to any Layers that
+    should be affected by this callback.
+
+    For example:
+
+    .. testcode::
+
+        dt = tf.Variable(1.0)
+
+        inp = tf.keras.Input((None, 10))
+        x = keras_spiking.SpikingActivation("relu", dt=dt)(inp)
+        x = keras_spiking.Lowpass(0.1, dt=dt)(x)
+        model = tf.keras.Model(inp, x)
+
+        callback = keras_spiking.callbacks.DtScheduler(
+            dt, tf.optimizers.schedules.ExponentialDecay(
+                1.0, decay_steps=5, decay_rate=0.9
+            )
+        )
+
+        model.compile(loss="mse", optimizer="sgd")
+        model.fit(
+            np.ones((100, 2, 10)),
+            np.ones((100, 2, 10)),
+            epochs=10,
+            batch_size=20,
+            callbacks=[callback],
+        )
+
+    .. testoutput::
+        :hide:
+
+        ...
+
+    Parameters
+    ----------
+    dt : ``tf.Variable``
+        Variable representing ``dt`` that has been passed to other Layers.
+    scheduler : ``tf.optimizers.schedules.LearningRateSchedule``
+        A schedule class that will update ``dt`` based on the training step (one
+        training step is one minibatch worth of training).
+    verbose : bool
+        If True, print out some information about ``dt`` updates during training.
+
+    Notes
+    -----
+    Because Variable values persist over time, any changes made to ``dt`` by this
+    callback will persist after training completes. For example, if you call ``fit``
+    with this callback and then ``predict`` later on, that ``predict`` call will be
+    using the last ``dt`` value set by this callback.
+    """
+
+    def __init__(self, dt, scheduler, verbose=False):
+        super().__init__()
+
+        if not isinstance(dt, tf.Variable):
+            raise TypeError("DtScheduler requires `dt` to be stored as a `tf.Variable`")
+
+        self.dt = dt
+        self.scheduler = scheduler
+        self.curr_epoch = None
+        self.verbose = verbose
+
+    def on_epoch_begin(self, epoch, logs=None):
+        """Keep track of the current epoch so we can count the total number of steps."""
+
+        self.curr_epoch = epoch
+        if self.verbose:
+            print("DtScheduler epoch=%d dt=%.4f" % (epoch, self.dt))
+
+    def on_train_batch_begin(self, batch, logs=None):
+        """Update ``dt`` variable based on the current training step."""
+
+        assert self.curr_epoch is not None
+        step = self.curr_epoch * self.params["steps"] + batch
+        self.dt.assign(self.scheduler(step))

--- a/keras_spiking/config.py
+++ b/keras_spiking/config.py
@@ -1,0 +1,25 @@
+"""
+Configuration options for KerasSpiking layers.
+"""
+
+
+class DefaultManager:
+    """
+    Manages the default parameter values for KerasSpiking layers.
+
+    Notes
+    -----
+    Do not instantiate this class directly, instead access it through
+    ``keras_spiking.default``.
+
+    Parameters
+    ----------
+    dt : float
+        Length of time (in seconds) represented by one time step. Defaults to 0.001s.
+    """
+
+    def __init__(self, dt=0.001):
+        self.dt = dt
+
+
+default = DefaultManager()

--- a/keras_spiking/layers.py
+++ b/keras_spiking/layers.py
@@ -6,6 +6,8 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework import smart_cond
 
+from keras_spiking import config
+
 
 class KerasSpikingCell(tf.keras.layers.Layer):
     """
@@ -21,7 +23,9 @@ class KerasSpikingCell(tf.keras.layers.Layer):
     state_size : int or tuple of int or ``tf.TensorShape``
         Shape of the cell state. If ``None``, use ``size``.
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     always_use_inference : bool
         If True, this layer will use its `.call_inference` behaviour during training,
         rather than `.call_training`.
@@ -31,11 +35,11 @@ class KerasSpikingCell(tf.keras.layers.Layer):
     """
 
     def __init__(
-        self, size, state_size=None, dt=0.001, always_use_inference=True, **kwargs
+        self, size, state_size=None, dt=None, always_use_inference=True, **kwargs
     ):
         super().__init__(**kwargs)
 
-        self.dt = dt
+        self.dt = config.default.dt if dt is None else dt
         self.always_use_inference = always_use_inference
         self.size = tf.TensorShape(size)
 
@@ -81,7 +85,9 @@ class KerasSpikingLayer(tf.keras.layers.Layer):
     Parameters
     ----------
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     return_sequences : bool
         Whether to return the full sequence of output values (default),
         or just the values on the last timestep.
@@ -110,7 +116,7 @@ class KerasSpikingLayer(tf.keras.layers.Layer):
 
     def __init__(
         self,
-        dt=0.001,
+        dt=None,
         return_sequences=True,
         return_state=False,
         stateful=False,
@@ -120,7 +126,7 @@ class KerasSpikingLayer(tf.keras.layers.Layer):
     ):
         super().__init__(**kwargs)
 
-        self.dt = dt
+        self.dt = config.default.dt if dt is None else dt
         self.return_sequences = return_sequences
         self.return_state = return_state
         self.stateful = stateful
@@ -235,7 +241,9 @@ class SpikingActivationCell(KerasSpikingCell):
     activation : callable
         Activation function to be converted to spiking equivalent.
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     seed : int
         Seed for random state initialization.
     spiking_aware_training : bool
@@ -253,7 +261,7 @@ class SpikingActivationCell(KerasSpikingCell):
         size,
         activation,
         *,
-        dt=0.001,
+        dt=None,
         seed=None,
         spiking_aware_training=True,
         **kwargs
@@ -400,7 +408,9 @@ class SpikingActivation(KerasSpikingLayer):
     activation : callable
         Activation function to be converted to spiking equivalent.
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     seed : int
         Seed for random state initialization.
     spiking_aware_training : bool
@@ -509,7 +519,9 @@ class LowpassCell(KerasSpikingCell):
     tau : float
         Time constant of filter (in seconds).
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     apply_during_training : bool
         If False, this layer will effectively be ignored during training (this
         often makes sense in concert with the swappable training behaviour in, e.g.,
@@ -527,7 +539,7 @@ class LowpassCell(KerasSpikingCell):
         size,
         tau,
         *,
-        dt=0.001,
+        dt=None,
         # TODO: better name for this parameter?
         apply_during_training=True,
         level_initializer="zeros",
@@ -632,7 +644,9 @@ class Lowpass(KerasSpikingLayer):
     tau : float
         Time constant of filter (in seconds).
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     apply_during_training : bool
         If False, this layer will effectively be ignored during training (this
         often makes sense in concert with the swappable training behaviour in, e.g.,
@@ -741,7 +755,9 @@ class AlphaCell(KerasSpikingCell):
     tau : float
         Time constant of filter (in seconds).
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     apply_during_training : bool
         If False, this layer will effectively be ignored during training (this
         often makes sense in concert with the swappable training behaviour in, e.g.,
@@ -759,7 +775,7 @@ class AlphaCell(KerasSpikingCell):
         size,
         tau,
         *,
-        dt=0.001,
+        dt=None,
         # TODO: better name for this parameter?
         apply_during_training=True,
         level_initializer="zeros",
@@ -900,7 +916,9 @@ class Alpha(KerasSpikingLayer):
     tau : float
         Time constant of filter (in seconds).
     dt : float
-        Length of time (in seconds) represented by one time step.
+        Length of time (in seconds) represented by one time step. If None, uses
+        `keras_spiking.default.dt <keras_spiking.config.DefaultManager>`
+        (which is 0.001 seconds by default).
     apply_during_training : bool
         If False, this layer will effectively be ignored during training (this
         often makes sense in concert with the swappable training behaviour in, e.g.,

--- a/keras_spiking/tests/test_callbacks.py
+++ b/keras_spiking/tests/test_callbacks.py
@@ -1,0 +1,57 @@
+import pytest
+import tensorflow as tf
+
+from keras_spiking import callbacks, layers
+
+
+def test_dt_scheduling(allclose, capsys):
+    dt_var = tf.Variable(0.0, trainable=False)
+    scheduler = tf.optimizers.schedules.PiecewiseConstantDecay(
+        [0, 16, 32], [1.0, 0.5, 0.25, 0.1]
+    )
+
+    class DtChecker(tf.keras.callbacks.Callback):
+        def __init__(self, var):
+            self.var = var
+            self.curr_epoch = None
+
+        def on_epoch_begin(self, epoch, logs=None):
+            self.curr_epoch = epoch
+
+        def on_train_batch_end(self, batch, logs=None):
+            step = self.curr_epoch * self.params["steps"] + batch
+
+            if step == 0:
+                assert allclose(self.var.numpy(), 1)
+            elif step <= 16:
+                assert allclose(self.var.numpy(), 0.5)
+            elif step <= 32:
+                assert allclose(self.var.numpy(), 0.25)
+            else:
+                assert allclose(self.var.numpy(), 0.1)
+
+    inp = x = tf.keras.Input((None, 10))
+    x = tf.keras.layers.Dense(10)(x)
+    x = layers.SpikingActivation("relu", dt=dt_var)(x)
+    x = layers.Lowpass(0.1, dt=dt_var)(x)
+    x = layers.Alpha(0.1, dt=dt_var)(x)
+    model = tf.keras.Model(inp, x)
+    model.compile(optimizer="sgd", loss="mse")
+
+    model.fit(
+        tf.ones((32, 5, 10)),
+        tf.ones((32, 5, 10)),
+        callbacks=[
+            DtChecker(dt_var),
+            callbacks.DtScheduler(dt_var, scheduler, verbose=True),
+        ],
+        epochs=10,
+        batch_size=2,
+    )
+
+    assert "DtScheduler epoch=0 dt=0.0000" in capsys.readouterr().out
+
+
+def test_dt_schedule_errors():
+    with pytest.raises(TypeError, match="stored as a `tf.Variable`"):
+        callbacks.DtScheduler(tf.constant(0), None)

--- a/keras_spiking/tests/test_config.py
+++ b/keras_spiking/tests/test_config.py
@@ -1,0 +1,36 @@
+import pytest
+
+from keras_spiking import config, layers
+
+
+@pytest.fixture(scope="function")
+def reset_defaults():
+    dt = config.default.dt
+    yield
+    config.default.dt = dt
+
+
+@pytest.mark.parametrize(
+    "Layer",
+    (
+        (lambda dt=None: layers.Lowpass(tau=0.01, dt=dt)),
+        (lambda dt=None: layers.SpikingActivation("relu", dt=dt)),
+        (lambda dt=None: layers.Alpha(tau=0.01, dt=dt)),
+    ),
+)
+def test_dt(Layer, reset_defaults):
+    layer = Layer()
+    assert layer.dt == 0.001
+
+    config.default.dt = 1
+
+    # changing the default after the fact does not affect already instantiated layers
+    assert layer.dt == 0.001
+
+    # newly created layers are affected
+    layer1 = Layer()
+    assert layer1.dt == 1
+
+    # manually overriding the default works properly
+    layer2 = Layer(dt=2)
+    assert layer2.dt == 2


### PR DESCRIPTION
Adds a callback that can be used to update ``dt`` during training, and modifies implementations to support ``dt`` being a ``tf.Variable`` (required by the callback).

Also noticed while testing this that we were assuming one-dimensional inputs to layers, so modified that to allow arbitrary input shapes (e.g. 2D convolutional layer outputs).