### PR TITLE
Reset layer states to get_initial_state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,10 +47,16 @@ Release history
 - Layers now support multi-dimensional inputs (e.g., output of ``Conv2D`` layers).
   (`#5`_)
 
+**Fixed**
+
+- KerasSpiking layers' ``reset_state`` now resets to the value of ``get_initial_state``
+  (as documented in the docstring), rather than all zeros. (`#12`_)
+
 .. _#3: https://github.com/nengo/keras-spiking/pull/3
 .. _#4: https://github.com/nengo/keras-spiking/pull/4
 .. _#5: https://github.com/nengo/keras-spiking/pull/5
 .. _#6: https://github.com/nengo/keras-spiking/pull/6
+.. _#12: https://github.com/nengo/keras-spiking/pull/12
 
 0.1.0 (August 14, 2020)
 -----------------------

--- a/keras_spiking/layers.py
+++ b/keras_spiking/layers.py
@@ -189,6 +189,12 @@ class KerasSpikingLayer(tf.keras.layers.Layer):
             Optional state array that can be used to override the values returned by
             ``cell.get_initial_state``, where ``cell`` is returned by ``build_cell``.
         """
+        if states is None:
+            states = self.layer.cell.get_initial_state(
+                batch_size=self.layer.states[0].shape[0],
+                dtype=self.layer.states[0].dtype,
+            )
+
         self.layer.reset_states(states=states)
 
     def get_config(self):


### PR DESCRIPTION
The default RNN behaviour is to reset to all zeros when `rnn.reset_state()` is called with no arguments. However, I think the behaviour that makes more sense (and the behaviour that was described in the docstring) is to reset to the value returned by `get_initial_state()`. This fixes the layers to have that behaviour.