### PR TITLE
Release candidate 0.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,8 +18,8 @@ Release history
    - Deprecated
    - Removed
 
-0.1.1 (unreleased)
-------------------
+0.2.0 (February 18, 2021)
+-------------------------
 
 *Compatible with TensorFlow 2.1.0 - 2.4.0*
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,8 @@ Release history
 
 - KerasSpiking layers' ``reset_state`` now resets to the value of ``get_initial_state``
   (as documented in the docstring), rather than all zeros. (`#12`_)
+- Fixed a bug with ``keras_spiking.Alpha`` on TensorFlow 2.1, where a symbolic tensor
+  in the initial state shape could not be converted to a Numpy array. (`#16`_)
 
 .. _#3: https://github.com/nengo/keras-spiking/pull/3
 .. _#4: https://github.com/nengo/keras-spiking/pull/4
@@ -61,6 +63,7 @@ Release history
 .. _#6: https://github.com/nengo/keras-spiking/pull/6
 .. _#7: https://github.com/nengo/keras-spiking/pull/7
 .. _#12: https://github.com/nengo/keras-spiking/pull/12
+.. _#16: https://github.com/nengo/keras-spiking/pull/16
 
 0.1.0 (August 14, 2020)
 -----------------------

--- a/keras_spiking/layers.py
+++ b/keras_spiking/layers.py
@@ -825,10 +825,12 @@ class AlphaCell(KerasSpikingCell):
 
     def get_initial_state(self, inputs=None, batch_size=None, dtype=None):
         """Get initial filter state."""
+        zeros_shape = tf.stack((batch_size, 1, self.flat_size))
+        tile_shape = tf.stack((batch_size, 1, 1))
         return tf.concat(
             [
-                tf.zeros((batch_size, 1, self.flat_size)),
-                tf.tile(self.initial_level[None, None, :], (batch_size, 1, 1)),
+                tf.zeros(zeros_shape),
+                tf.tile(self.initial_level[None, None, :], tile_shape),
             ],
             axis=1,
         )

--- a/keras_spiking/version.py
+++ b/keras_spiking/version.py
@@ -6,8 +6,8 @@ a release version. Release versions are git tagged with the version.
 """
 
 name = "keras-spiking"
-version_info = (0, 1, 1)  # (major, minor, patch)
-dev = 0  # set to None for releases
+version_info = (0, 2, 0)  # (major, minor, patch)
+dev = None  # set to None for releases
 
 version = "{v}{dev}".format(
     v=".".join(str(v) for v in version_info),


### PR DESCRIPTION
I don't know why the Alpha layer bug wasn't showing up in our CI test for TensorFlow 2.1; all I can guess is that it's a GPU-only problem (we test 2.1 on CPU only).