### PR TITLE
Support constraints with Lowpass[Cell] and Alpha[Cell]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@ Release history
   ``initial_level_constraint`` and ``tau_var_constraint`` to customize how their
   respective parameters are constrained during training. (`#21`_)
 
+**Changed**
+
+- The ``tau`` time constants for ``LowpassCell``, ``Lowpass``, ``AlphaCell``, and
+  ``Alpha`` are now always clipped to be positive in the forward pass rather than
+  constraining the underlying trainable weights in between gradient updates. (`#21`_)
+
 **Fixed**
 
 - ``SpikingActivation``, ``Lowpass``, and ``Alpha`` layers will now correctly use

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Release history
    - Deprecated
    - Removed
 
-0.2.1 (unreleased)
+0.3.0 (unreleased)
 ------------------
 
 *Compatible with TensorFlow 2.1.0 - 2.5.0*
@@ -26,7 +26,7 @@ Release history
 **Added**
 
 - ``LowpassCell``, ``Lowpass``, ``AlphaCell``, and ``Alpha`` layers now accept both
-  ``initial_level_constraint`` and ``tau_var_constraint`` to customize how their
+  ``initial_level_constraint`` and ``tau_constraint`` to customize how their
   respective parameters are constrained during training. (`#21`_)
 
 **Changed**
@@ -34,6 +34,9 @@ Release history
 - The ``tau`` time constants for ``LowpassCell``, ``Lowpass``, ``AlphaCell``, and
   ``Alpha`` are now always clipped to be positive in the forward pass rather than
   constraining the underlying trainable weights in between gradient updates. (`#21`_)
+- Renamed the ``Lowpass/Alpha`` ``tau`` parameter to ``tau_initializer``, and it now
+  accepts ``tf.keras.initializers.Initializer`` objects (in addition to floats, as
+  before).  Renamed the ``tau_var`` weight attribute to ``tau``. (`#21`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,12 +23,19 @@ Release history
 
 *Compatible with TensorFlow 2.1.0 - 2.5.0*
 
+**Added**
+
+- ``LowpassCell``, ``Lowpass``, ``AlphaCell``, and ``Alpha`` layers now accept both
+  ``initial_level_constraint`` and ``tau_var_constraint`` to customize how their
+  respective parameters are constrained during training. (`#21`_)
+
 **Fixed**
 
 - ``SpikingActivation``, ``Lowpass``, and ``Alpha`` layers will now correctly use
   ``keras_spiking.default.dt``. (`#20`_)
 
 .. _#20: https://github.com/nengo/keras-spiking/pull/20
+.. _#21: https://github.com/nengo/keras-spiking/pull/21
 
 0.2.0 (February 18, 2021)
 -------------------------

--- a/docs/examples/spiking-fashion-mnist.ipynb
+++ b/docs/examples/spiking-fashion-mnist.ipynb
@@ -608,7 +608,7 @@
     "        tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(128)),\n",
     "        keras_spiking.SpikingActivation(\"relu\", spiking_aware_training=True),\n",
     "        # add a lowpass filter on output of spiking layer\n",
-    "        keras_spiking.Lowpass(tau=0.1, return_sequences=False),\n",
+    "        keras_spiking.Lowpass(0.1, return_sequences=False),\n",
     "        tf.keras.layers.Dense(10),\n",
     "    ]\n",
     ")\n",

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -17,6 +17,14 @@ Regularizers
     .. autoautosummary:: keras_spiking.regularizers
         :nosignatures:
 
+Constraints
+-----------
+
+.. automodule:: keras_spiking.constraints
+
+    .. autoautosummary:: keras_spiking.constraints
+        :nosignatures:
+
 Callbacks
 ---------
 

--- a/keras_spiking/__init__.py
+++ b/keras_spiking/__init__.py
@@ -2,7 +2,7 @@
 
 __copyright__ = "2020-2021, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"
-from keras_spiking import callbacks, layers, model_energy, regularizers
+from keras_spiking import callbacks, constraints, layers, model_energy, regularizers
 from keras_spiking.config import default
 from keras_spiking.layers import (
     Alpha,

--- a/keras_spiking/constraints.py
+++ b/keras_spiking/constraints.py
@@ -1,0 +1,36 @@
+"""
+Custom constraints for weight tensors in Keras models.
+"""
+
+import tensorflow as tf
+
+
+class Mean(tf.keras.constraints.Constraint):
+    """Constrains weight tensors to be their mean.
+
+    Parameters
+    ----------
+    axis : int
+        Axis used to compute the mean and repeat its value. Defaults to the last axis.
+    non_neg : boolean
+        Whether to constrain the resulting mean to be non-negative as well.
+    """
+
+    def __init__(self, axis=-1, non_neg=False):
+        self.axis = axis
+        self.non_neg = non_neg
+        self._post_constraint = tf.keras.constraints.get("non_neg" if non_neg else None)
+
+    def __call__(self, w):
+        r = tf.repeat(
+            input=tf.math.reduce_mean(w, axis=self.axis, keepdims=True),
+            repeats=tf.shape(w)[self.axis],
+            axis=self.axis,
+        )
+        if self._post_constraint is not None:
+            r = self._post_constraint(r)
+        return r
+
+    def get_config(self):
+        """Return config of layer (for serialization during model saving/loading)."""
+        return {"axis": self.axis, "non_neg": self.non_neg}

--- a/keras_spiking/constraints.py
+++ b/keras_spiking/constraints.py
@@ -12,25 +12,18 @@ class Mean(tf.keras.constraints.Constraint):
     ----------
     axis : int
         Axis used to compute the mean and repeat its value. Defaults to the last axis.
-    non_neg : boolean
-        Whether to constrain the resulting mean to be non-negative as well.
     """
 
-    def __init__(self, axis=-1, non_neg=False):
+    def __init__(self, axis=-1):
         self.axis = axis
-        self.non_neg = non_neg
-        self._post_constraint = tf.keras.constraints.get("non_neg" if non_neg else None)
 
     def __call__(self, w):
-        r = tf.repeat(
+        return tf.repeat(
             input=tf.math.reduce_mean(w, axis=self.axis, keepdims=True),
             repeats=tf.shape(w)[self.axis],
             axis=self.axis,
         )
-        if self._post_constraint is not None:
-            r = self._post_constraint(r)
-        return r
 
     def get_config(self):
         """Return config of layer (for serialization during model saving/loading)."""
-        return {"axis": self.axis, "non_neg": self.non_neg}
+        return {"axis": self.axis}

--- a/keras_spiking/layers.py
+++ b/keras_spiking/layers.py
@@ -535,6 +535,11 @@ class LowpassCell(KerasSpikingCell):
         then we often don't need to filter them either).
     level_initializer : str or ``tf.keras.initializers.Initializer``
         Initializer for filter state.
+    initial_level_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``initial_level``.
+    tau_var_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``tau_var``. For example, `.Mean` with ``non_neg=True``
+        will share the same time constant across all of the lowpass filters.
     kwargs : dict
         Passed on to `tf.keras.layers.Layer
         <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer>`_.
@@ -549,6 +554,8 @@ class LowpassCell(KerasSpikingCell):
         # TODO: better name for this parameter?
         apply_during_training=True,
         level_initializer="zeros",
+        initial_level_constraint=None,
+        tau_var_constraint="non_neg",
         **kwargs,
     ):
         super().__init__(
@@ -564,6 +571,10 @@ class LowpassCell(KerasSpikingCell):
         self.tau = tau
         self.apply_during_training = apply_during_training
         self.level_initializer = tf.initializers.get(level_initializer)
+        self.initial_level_constraint = tf.keras.constraints.get(
+            initial_level_constraint
+        )
+        self.tau_var_constraint = tf.keras.constraints.get(tau_var_constraint)
 
     def build(self, input_shapes):
         """Build parameters associated with this layer."""
@@ -575,6 +586,7 @@ class LowpassCell(KerasSpikingCell):
             shape=[1] + self.size.as_list(),
             initializer=self.level_initializer,
             trainable=self.apply_during_training,
+            constraint=self.initial_level_constraint,
         )
 
         self.tau_var = self.add_weight(
@@ -582,7 +594,7 @@ class LowpassCell(KerasSpikingCell):
             shape=[1] + self.state_size.as_list(),
             initializer=tf.initializers.constant(np.ones(self.state_size) * self.tau),
             trainable=self.apply_during_training,
-            constraint=tf.keras.constraints.NonNeg(),
+            constraint=self.tau_var_constraint,
         )
 
     def get_initial_state(self, inputs=None, batch_size=None, dtype=None):
@@ -614,6 +626,12 @@ class LowpassCell(KerasSpikingCell):
                 apply_during_training=self.apply_during_training,
                 level_initializer=tf.keras.initializers.serialize(
                     self.level_initializer
+                ),
+                initial_level_constraint=tf.keras.constraints.serialize(
+                    self.initial_level_constraint
+                ),
+                tau_var_constraint=tf.keras.constraints.serialize(
+                    self.tau_var_constraint
                 ),
             )
         )
@@ -660,6 +678,11 @@ class Lowpass(KerasSpikingLayer):
         then we often don't need to filter them either).
     level_initializer : str or ``tf.keras.initializers.Initializer``
         Initializer for filter state.
+    initial_level_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``initial_level``.
+    tau_var_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``tau_var``. For example, `.Mean` with ``non_neg=True``
+        will share the same time constant across all of the lowpass filters.
     return_sequences : bool
         Whether to return the full sequence of filtered output (default),
         or just the output on the last timestep.
@@ -693,6 +716,8 @@ class Lowpass(KerasSpikingLayer):
         dt=None,
         apply_during_training=True,
         level_initializer="zeros",
+        initial_level_constraint=None,
+        tau_var_constraint="non_neg",
         return_sequences=True,
         return_state=False,
         stateful=False,
@@ -713,6 +738,10 @@ class Lowpass(KerasSpikingLayer):
         self.tau = tau
         self.apply_during_training = apply_during_training
         self.level_initializer = tf.keras.initializers.get(level_initializer)
+        self.initial_level_constraint = tf.keras.constraints.get(
+            initial_level_constraint
+        )
+        self.tau_var_constraint = tf.keras.constraints.get(tau_var_constraint)
 
     def build_cell(self, input_shapes):
         return LowpassCell(
@@ -721,6 +750,8 @@ class Lowpass(KerasSpikingLayer):
             dt=self.dt,
             apply_during_training=self.apply_during_training,
             level_initializer=self.level_initializer,
+            initial_level_constraint=self.initial_level_constraint,
+            tau_var_constraint=self.tau_var_constraint,
         )
 
     def get_config(self):
@@ -731,6 +762,12 @@ class Lowpass(KerasSpikingLayer):
                 apply_during_training=self.apply_during_training,
                 level_initializer=tf.keras.initializers.serialize(
                     self.level_initializer
+                ),
+                initial_level_constraint=tf.keras.constraints.serialize(
+                    self.initial_level_constraint
+                ),
+                tau_var_constraint=tf.keras.constraints.serialize(
+                    self.tau_var_constraint
                 ),
             )
         )
@@ -771,6 +808,11 @@ class AlphaCell(KerasSpikingCell):
         then we often don't need to filter them either).
     level_initializer : str or ``tf.keras.initializers.Initializer``
         Initializer for filter state.
+    initial_level_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``initial_level``.
+    tau_var_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``tau_var``. For example, `.Mean` with ``non_neg=True``
+        will share the same time constant across all of the lowpass filters.
     kwargs : dict
         Passed on to `tf.keras.layers.Layer
         <https://www.tensorflow.org/api_docs/python/tf/keras/layers/Layer>`_.
@@ -785,6 +827,8 @@ class AlphaCell(KerasSpikingCell):
         # TODO: better name for this parameter?
         apply_during_training=True,
         level_initializer="zeros",
+        initial_level_constraint=None,
+        tau_var_constraint="non_neg",
         **kwargs,
     ):
         super().__init__(
@@ -802,6 +846,10 @@ class AlphaCell(KerasSpikingCell):
         self.tau = tau
         self.apply_during_training = apply_during_training
         self.level_initializer = tf.initializers.get(level_initializer)
+        self.initial_level_constraint = tf.keras.constraints.get(
+            initial_level_constraint
+        )
+        self.tau_var_constraint = tf.keras.constraints.get(tau_var_constraint)
 
     def build(self, input_shapes):
         """Build parameters associated with this layer."""
@@ -813,6 +861,7 @@ class AlphaCell(KerasSpikingCell):
             shape=(self.flat_size,),
             initializer=self.level_initializer,
             trainable=self.apply_during_training,
+            constraint=self.initial_level_constraint,
         )
 
         self.tau_var = self.add_weight(
@@ -820,7 +869,7 @@ class AlphaCell(KerasSpikingCell):
             shape=(self.flat_size,),
             initializer=tf.initializers.constant(np.ones(self.flat_size) * self.tau),
             trainable=self.apply_during_training,
-            constraint=tf.keras.constraints.NonNeg(),
+            constraint=self.tau_var_constraint,
         )
 
     def get_initial_state(self, inputs=None, batch_size=None, dtype=None):
@@ -889,6 +938,12 @@ class AlphaCell(KerasSpikingCell):
                 level_initializer=tf.keras.initializers.serialize(
                     self.level_initializer
                 ),
+                initial_level_constraint=tf.keras.constraints.serialize(
+                    self.initial_level_constraint
+                ),
+                tau_var_constraint=tf.keras.constraints.serialize(
+                    self.tau_var_constraint
+                ),
             )
         )
 
@@ -934,6 +989,11 @@ class Alpha(KerasSpikingLayer):
         then we often don't need to filter them either).
     level_initializer : str or ``tf.keras.initializers.Initializer``
         Initializer for filter state.
+    initial_level_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``initial_level``.
+    tau_var_constraint : str or ``tf.keras.constraints.Constraint``
+        Constraint for ``tau_var``. For example, `.Mean` with ``non_neg=True``
+        will share the same time constant across all of the lowpass filters.
     return_sequences : bool
         Whether to return the full sequence of filtered output (default),
         or just the output on the last timestep.
@@ -967,6 +1027,8 @@ class Alpha(KerasSpikingLayer):
         dt=None,
         apply_during_training=True,
         level_initializer="zeros",
+        initial_level_constraint=None,
+        tau_var_constraint="non_neg",
         return_sequences=True,
         return_state=False,
         stateful=False,
@@ -987,6 +1049,10 @@ class Alpha(KerasSpikingLayer):
         self.tau = tau
         self.apply_during_training = apply_during_training
         self.level_initializer = tf.keras.initializers.get(level_initializer)
+        self.initial_level_constraint = tf.keras.constraints.get(
+            initial_level_constraint
+        )
+        self.tau_var_constraint = tf.keras.constraints.get(tau_var_constraint)
 
     def build_cell(self, input_shapes):
         return AlphaCell(
@@ -995,6 +1061,8 @@ class Alpha(KerasSpikingLayer):
             dt=self.dt,
             apply_during_training=self.apply_during_training,
             level_initializer=self.level_initializer,
+            initial_level_constraint=self.initial_level_constraint,
+            tau_var_constraint=self.tau_var_constraint,
         )
 
     def get_config(self):
@@ -1005,6 +1073,12 @@ class Alpha(KerasSpikingLayer):
                 apply_during_training=self.apply_during_training,
                 level_initializer=tf.keras.initializers.serialize(
                     self.level_initializer
+                ),
+                initial_level_constraint=tf.keras.constraints.serialize(
+                    self.initial_level_constraint
+                ),
+                tau_var_constraint=tf.keras.constraints.serialize(
+                    self.tau_var_constraint
                 ),
             )
         )

--- a/keras_spiking/tests/test_config.py
+++ b/keras_spiking/tests/test_config.py
@@ -13,9 +13,9 @@ def reset_defaults():
 @pytest.mark.parametrize(
     "Layer",
     (
-        (lambda **kwargs: layers.Lowpass(tau=0.01, **kwargs)),
+        (lambda **kwargs: layers.Lowpass(tau_initializer=0.01, **kwargs)),
         (lambda **kwargs: layers.SpikingActivation("relu", **kwargs)),
-        (lambda **kwargs: layers.Alpha(tau=0.01, **kwargs)),
+        (lambda **kwargs: layers.Alpha(tau_initializer=0.01, **kwargs)),
     ),
 )
 def test_dt(Layer, reset_defaults):

--- a/keras_spiking/tests/test_constraints.py
+++ b/keras_spiking/tests/test_constraints.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+import tensorflow as tf
+from packaging import version
+
+from keras_spiking.constraints import Mean
+
+
+def simple_dense_model(n_features, n_units, axis=0):
+    inp = tf.keras.Input((None, n_features))
+    dense = tf.keras.layers.Dense(
+        units=n_units,
+        kernel_constraint=Mean(axis=axis),
+        bias_constraint=Mean(non_neg=True),
+    )(inp)
+    out = tf.keras.layers.Dense(n_features)(dense)
+    return tf.keras.Model(inp, out)
+
+
+@pytest.mark.parametrize("axis", (0, 1))
+def test_mean_constraint(axis, rng):
+    n_features = 3
+    n_units = 10
+    x, y = rng.rand(2, 32, 100, n_features).astype(np.float32)
+
+    model = simple_dense_model(n_features=n_features, n_units=n_units, axis=axis)
+    model.compile(loss="mse", optimizer=tf.optimizers.SGD(0.1))
+    model.fit(x, x - 1, epochs=1, verbose=0)
+
+    kernel_weights = model.layers[1].weights[0].numpy()
+    bias_weights = model.layers[1].weights[1].numpy()
+
+    assert kernel_weights.shape == (n_features, n_units)
+    assert bias_weights.shape == (n_units,)
+
+    learned_kernel = np.asarray(np.unique(kernel_weights, axis=axis))
+    if axis == 0:
+        assert learned_kernel.shape == (1, n_units)
+    elif axis == 1:
+        assert learned_kernel.shape == (n_features, 1)
+    else:
+        assert False
+
+    learned_bias = np.unique(bias_weights)
+    assert len(learned_bias) == 1
+    assert (learned_bias >= 0).all()
+
+
+def test_save_load_mean_constraint(tmp_path):
+    model = simple_dense_model(n_features=10, n_units=20)
+
+    model.save(str(tmp_path))
+
+    # Note: If custom_objects does not include the custom constraint then it will be
+    # missing in the loaded model. It will also be missing in earlier TF versions.
+    model_load = tf.keras.models.load_model(
+        str(tmp_path), custom_objects={"Mean": Mean}
+    )
+    if version.parse(tf.__version__) < version.parse("2.4.0"):
+        pytest.xfail(f"TensorFlow {tf.__version__} does not load custom constraints")
+
+    assert len(model_load.layers[1].weights) == 2
+    assert isinstance(model_load.layers[1].weights[0].constraint, Mean)
+    assert isinstance(model_load.layers[1].weights[1].constraint, Mean)

--- a/keras_spiking/tests/test_constraints.py
+++ b/keras_spiking/tests/test_constraints.py
@@ -11,7 +11,7 @@ def simple_dense_model(n_features, n_units, axis=0):
     dense = tf.keras.layers.Dense(
         units=n_units,
         kernel_constraint=Mean(axis=axis),
-        bias_constraint=Mean(non_neg=True),
+        bias_constraint=Mean(),
     )(inp)
     out = tf.keras.layers.Dense(n_features)(dense)
     return tf.keras.Model(inp, out)
@@ -43,7 +43,6 @@ def test_mean_constraint(axis, rng):
 
     learned_bias = np.unique(bias_weights)
     assert len(learned_bias) == 1
-    assert (learned_bias >= 0).all()
 
 
 def test_save_load_mean_constraint(tmp_path):

--- a/keras_spiking/tests/test_layers.py
+++ b/keras_spiking/tests/test_layers.py
@@ -322,22 +322,6 @@ def test_filter_trainable(Layer, allclose):
     )
 
 
-def test_lowpass_alpha_validation():
-    with pytest.raises(ValueError, match="tau must be a positive number"):
-        layers.LowpassCell(tau=0, size=1)
-
-    with pytest.raises(ValueError, match="tau must be a positive number"):
-        # note: error won't be raised until layer is applied (when LowpassCell is built)
-        layers.Lowpass(tau=0)(np.zeros((1, 1, 1), dtype=np.float32))
-
-    with pytest.raises(ValueError, match="tau must be a positive number"):
-        layers.AlphaCell(tau=0, size=1)
-
-    with pytest.raises(ValueError, match="tau must be a positive number"):
-        # note: error won't be raised until layer is applied (when AlphaCell is built)
-        layers.Alpha(tau=0)(np.zeros((1, 1, 1), dtype=np.float32))
-
-
 @pytest.mark.parametrize(
     "Layer",
     (
@@ -402,7 +386,7 @@ def test_filter_constraints(layer_cls, rng):
     kwargs = dict(
         size=n_features,
         tau=initial_tau,
-        tau_var_constraint=constraints.Mean(non_neg=True),
+        tau_var_constraint=constraints.Mean(),
         initial_level_constraint=tf.keras.constraints.UnitNorm(axis=-1),
     )
     if issubclass(layer_cls, layers.KerasSpikingCell):
@@ -429,7 +413,7 @@ def test_filter_constraints(layer_cls, rng):
     learned_tau = np.unique(tau_var_weights.numpy())
     assert len(learned_tau) == 1
 
-    assert 0.01 < learned_tau.item() < 0.9 * initial_tau
+    assert 0.1 * initial_tau < learned_tau.item() < 0.9 * initial_tau
 
     initial_level_weights = model.layers[1].weights[0]
     if layer_cls in (layers.Lowpass, layers.LowpassCell):

--- a/keras_spiking/version.py
+++ b/keras_spiking/version.py
@@ -6,7 +6,7 @@ a release version. Release versions are git tagged with the version.
 """
 
 name = "keras-spiking"
-version_info = (0, 2, 1)  # (major, minor, patch)
+version_info = (0, 3, 0)  # (major, minor, patch)
 dev = 0  # set to None for releases
 
 version = "{v}{dev}".format(


### PR DESCRIPTION
Addresses #15 by taking the suggested approach of supporting constraints, and implementing a constraint that sets all of the time constants to their mean (and optionally making that non-negative).

TODO:
 - [x] After collecting feedback on this implementation, the solution could be replicated across `Lowpass` and all of the other filter cells and RNN layers.
 - [x] Update changelog