### PR TITLE
WIP: Work with other float dtypes (float64, float16)

### DIFF
--- a/keras_spiking/layers.py
+++ b/keras_spiking/layers.py
@@ -485,6 +485,7 @@ class SpikingActivation(KerasSpikingLayer):
             dt=self.dt,
             seed=self.seed,
             spiking_aware_training=self.spiking_aware_training,
+            dtype=self.dtype,
         )
 
     def get_config(self):
@@ -760,6 +761,7 @@ class Lowpass(KerasSpikingLayer):
             level_initializer=self.level_initializer,
             initial_level_constraint=self.initial_level_constraint,
             tau_constraint=self.tau_constraint,
+            dtype=self.dtype,
         )
 
     def get_config(self):
@@ -1075,6 +1077,7 @@ class Alpha(KerasSpikingLayer):
             level_initializer=self.level_initializer,
             initial_level_constraint=self.initial_level_constraint,
             tau_constraint=self.tau_constraint,
+            dtype=self.dtype,
         )
 
     def get_config(self):


### PR DESCRIPTION
Just a start at this, since it came up when working on another repo.

TODO:
- [ ] Test that dtypes are properly conserved in layers and cells (i.e. output dtype matches layer dtype).
- [ ] Run all/most tests with multiple dtypes.
- [ ] Change epsilon (1e-8) used in e.g. `Lowpass` to work with other dtypes (e.g. the current value of 1e-8 will go to 0 if converted to float16). In the specific case of `Lowpass`, this epsilon probably doesn't need to be so small, since even `np.exp(-1 / 1e-3) == 0.0`. 